### PR TITLE
Fix extras_require duplicate key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,15 +13,15 @@ setup(
         "faiss-cpu>=1.7.0"
     ],
     extras_require={
-        "dev": ["pytest", "pytest-asyncio", "black", "flake8"],
+        "dev": [
+            "pytest>=7.0.0",
+            "pytest-asyncio",
+            "flake8>=5.0.0",
+            "black>=22.0.0",
+            "mypy>=0.950",
+        ],
         "gpu": ["faiss-gpu"],
-            "dev": [
-                "pytest>=7.0.0",
-                "flake8>=5.0.0",
-                "black>=22.0.0",
-                "mypy>=0.950",
-            ]
-        },
+    },
         python_requires=">=3.8",
         entry_points={
             "console_scripts": [


### PR DESCRIPTION
## Summary
- remove duplicate `dev` key in `extras_require` in setup.py
- merge dev dependencies into a single list

## Testing
- `python setup.py check` *(fails: No module named 'setuptools')*
- `flake8 setup.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684a730757108324a8d570802dc176b9