### PR TITLE
Add config.json loading and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ python main.py --help
 └── requirements.txt    # 의존성 목록
 ```
 
+## config.json 파일
+
+모델 빌드 파라미터가 담긴 TensorRT-LLM용 설정 파일입니다. `build_config.max_seq_len` 값이
+파이프라인의 기본 컨텍스트 길이로 사용되며, 필요 시 파일을 수정해 최대 입력 길이를 조정할 수 있습니다.
+
 ## 의존성
 
 - Python 3.8 이상

--- a/config/settings.py
+++ b/config/settings.py
@@ -2,9 +2,10 @@ from dataclasses import dataclass
 import os
 from pathlib import Path
 from typing import Optional
+import json
 
 # 프로젝트 루트 디렉토리
-ROOT_DIR = Path(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))  
+ROOT_DIR = Path(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # 데이터 및 캐시 경로
 DATA_DIR = ROOT_DIR / "data"
@@ -14,6 +15,16 @@ LOG_DIR = DATA_DIR / "logs"
 # 필요한 디렉토리 생성
 for directory in [DATA_DIR, CACHE_DIR, LOG_DIR]:
     directory.mkdir(parents=True, exist_ok=True)
+
+
+def load_ctx_len_from_json(path: Path) -> int:
+    """config.json에서 max_seq_len 값을 읽어 ctx_len 기본값으로 사용"""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return int(data.get("build_config", {}).get("max_seq_len", 2048))
+    except Exception:
+        return 2048
 
 @dataclass
 class TritonConfig:
@@ -31,7 +42,7 @@ class AppConfig:
     cache_ttl: int = 3600
     cache_max_size: int = 1000
     model_path: str = "./"
-    ctx_len: int = 2048
+    ctx_len: int = load_ctx_len_from_json(ROOT_DIR / "config.json")
 
 # 기본 설정 인스턴스 생성
 config = AppConfig()


### PR DESCRIPTION
## Summary
- document purpose of `config.json`
- load `config.json` in settings and pipeline to set context length automatically

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a743afad0832498dbe7315c8fbbc1